### PR TITLE
タスクの編集・削除・ステータス変更のE2Eテストを追加 HOXBL-88

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -105,7 +105,7 @@ jobs:
         env:
           CLIENT_PORT: 3000
           SERVER_PORT: 3001
-          NEXT_PUBLIC_API_BASE_URL: "http://localhost:3001/api"
+          NEXT_PUBLIC_API_BASE_URL: "http://localhost:3001"
           # Supabase test environment variables (mocked)
           NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: test_publishable_key

--- a/app/client/e2e/todo/helpers/task-setup.ts
+++ b/app/client/e2e/todo/helpers/task-setup.ts
@@ -1,9 +1,14 @@
 import type { Page } from '@playwright/test';
-import type { Task } from '@/packages/shared-schemas/src/tasks';
+import type {
+  ChangeTaskStatusBody,
+  Task,
+  UpdateTaskBody,
+} from '@/packages/shared-schemas/src/tasks';
 import { setupAuthenticatedApiMocks } from '../../shared/helpers/auth-session';
 import { expectDashboard } from '../../shared/helpers/dashboard';
 
 const DEFAULT_USER_ID = '22222222-2222-4222-8222-222222222222';
+const TASK_ID_PATH = /^\/api\/tasks\/([^/]+)(?:\/status)?$/;
 
 /**
  * テスト用タスクオブジェクトを生成するファクトリ関数。
@@ -27,11 +32,23 @@ export function buildMockTask(overrides?: Partial<Task>): Task {
 export interface SetupTaskApiMocksOptions {
   initialTasks?: Task[];
   failCreate?: boolean;
+  failUpdate?: boolean;
+}
+
+function notFoundResponse() {
+  return {
+    status: 404 as const,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      success: false,
+      error: { message: 'タスクが見つかりません' },
+    }),
+  };
 }
 
 /**
- * `/api/tasks` への一覧取得・作成リクエストをインターセプトするモック。
- * 作成成功時はクロージャ内のタスク配列へ反映し、以降のGETに反映する。
+ * `/api/tasks` への一覧取得・作成・更新・削除・ステータス変更リクエストをインターセプトするモック。
+ * 変更成功時はクロージャ内のタスク配列へ反映し、以降のGETに反映する。
  */
 export async function setupTaskApiMocks(
   page: Page,
@@ -39,7 +56,7 @@ export async function setupTaskApiMocks(
 ): Promise<void> {
   const tasks: Task[] = [...(options?.initialTasks ?? [])];
 
-  await page.route('**/api/tasks*', async (route) => {
+  await page.route('**/api/tasks**', async (route) => {
     const request = route.request();
     const method = request.method();
 
@@ -79,6 +96,82 @@ export async function setupTaskApiMocks(
         status: 201,
         contentType: 'application/json',
         body: JSON.stringify({ success: true, data: newTask }),
+      });
+      return;
+    }
+
+    const idMatch = new URL(request.url()).pathname.match(TASK_ID_PATH);
+    if (!idMatch) {
+      await route.continue();
+      return;
+    }
+
+    const taskId = idMatch[1];
+    const taskIndex = tasks.findIndex((t) => t.id === taskId);
+
+    if (method === 'PUT') {
+      if (options?.failUpdate) {
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: false,
+            error: { message: 'タスク更新に失敗しました' },
+          }),
+        });
+        return;
+      }
+
+      if (taskIndex === -1) {
+        await route.fulfill(notFoundResponse());
+        return;
+      }
+
+      const requestBody = request.postDataJSON() as Partial<UpdateTaskBody>;
+      const updatedTask: Task = {
+        ...tasks[taskIndex],
+        ...requestBody,
+        updatedAt: new Date().toISOString(),
+      };
+      tasks[taskIndex] = updatedTask;
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: updatedTask }),
+      });
+      return;
+    }
+
+    if (method === 'DELETE') {
+      if (taskIndex === -1) {
+        await route.fulfill(notFoundResponse());
+        return;
+      }
+      tasks.splice(taskIndex, 1);
+
+      await route.fulfill({ status: 204 });
+      return;
+    }
+
+    if (method === 'PATCH') {
+      if (taskIndex === -1) {
+        await route.fulfill(notFoundResponse());
+        return;
+      }
+
+      const requestBody = request.postDataJSON() as ChangeTaskStatusBody;
+      const updatedTask: Task = {
+        ...tasks[taskIndex],
+        status: requestBody.status,
+        updatedAt: new Date().toISOString(),
+      };
+      tasks[taskIndex] = updatedTask;
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: updatedTask }),
       });
       return;
     }

--- a/app/client/e2e/todo/task-edit-delete-status.spec.ts
+++ b/app/client/e2e/todo/task-edit-delete-status.spec.ts
@@ -1,0 +1,144 @@
+import { expect, type Page } from '@playwright/test';
+import { test } from '../shared/helpers/auth-session';
+import { buildMockTask, openDashboardWithTasks } from './helpers/task-setup';
+
+/**
+ * 編集モーダルを開いてタイトルを入力する。
+ * `fill`直後の値反映を待つことで、コントロール入力の状態更新前に
+ * 保存/キャンセルボタンを押してしまう競合を防ぐ。
+ */
+async function openTaskEditModalAndFillTitle(
+  page: Page,
+  title: string,
+): Promise<void> {
+  await page.getByRole('button', { name: 'タスクを編集' }).click();
+  const titleInput = page.getByLabel('タイトル', { exact: true });
+  await titleInput.fill(title);
+  await expect(titleInput).toHaveValue(title);
+}
+
+test.describe('タスク編集・削除・ステータス変更 E2Eテスト', () => {
+  test('編集を保存すると一覧のタイトルが更新されモーダルが閉じる', async ({
+    createAuthenticatedPage,
+  }) => {
+    // Given: 既存タスクが1件表示されている
+    const page = await createAuthenticatedPage();
+    await openDashboardWithTasks(page, {
+      initialTasks: [buildMockTask({ title: '編集前タスク' })],
+    });
+
+    // When: 編集モーダルでタイトルを変更して保存する
+    await openTaskEditModalAndFillTitle(page, '編集後タスク');
+    await page.getByRole('button', { name: '保存' }).click();
+
+    // Then: 一覧のタイトルが更新され、モーダルが閉じる
+    await expect(
+      page.getByRole('heading', { level: 3, name: '編集後タスク' }),
+    ).toBeVisible();
+    await expect(page.getByRole('dialog')).toBeHidden();
+  });
+
+  test('タイトルを空にして保存するとバリデーションエラーが表示される', async ({
+    createAuthenticatedPage,
+  }) => {
+    // Given: 既存タスクが1件表示されている
+    const page = await createAuthenticatedPage();
+    await openDashboardWithTasks(page, {
+      initialTasks: [buildMockTask({ title: '既存タスク' })],
+    });
+
+    // When: タイトルを空にして保存する
+    await openTaskEditModalAndFillTitle(page, '');
+    await page.getByRole('button', { name: '保存' }).click();
+
+    // Then: バリデーションエラーが表示され、モーダルは開いたまま
+    await expect(
+      page.getByRole('alert').filter({ hasText: 'タイトルを入力してください' }),
+    ).toBeVisible();
+    await expect(page.getByRole('dialog')).toBeVisible();
+  });
+
+  test('編集APIが失敗するとエラーメッセージが表示されモーダルが開いたまま', async ({
+    createAuthenticatedPage,
+  }) => {
+    // Given: タスク更新APIが失敗するダッシュボード
+    const page = await createAuthenticatedPage();
+    await openDashboardWithTasks(page, {
+      initialTasks: [buildMockTask({ title: '更新に失敗するタスク' })],
+      failUpdate: true,
+    });
+
+    // When: タイトルを変更して保存する
+    await openTaskEditModalAndFillTitle(page, '更新後タイトル');
+    await page.getByRole('button', { name: '保存' }).click();
+
+    // Then: エラーメッセージが表示され、モーダルは開いたまま
+    await expect(
+      page.getByRole('alert').filter({ hasText: 'タスク更新に失敗しました' }),
+    ).toBeVisible();
+    await expect(page.getByRole('dialog')).toBeVisible();
+  });
+
+  test('キャンセルすると変更が破棄されモーダルが閉じる', async ({
+    createAuthenticatedPage,
+  }) => {
+    // Given: 既存タスクが1件表示されている
+    const page = await createAuthenticatedPage();
+    await openDashboardWithTasks(page, {
+      initialTasks: [buildMockTask({ title: '変更しないタスク' })],
+    });
+
+    // When: タイトルを変更した後、キャンセルする
+    await openTaskEditModalAndFillTitle(page, '変更後タイトル');
+    await page.getByRole('button', { name: 'キャンセル' }).click();
+
+    // Then: モーダルが閉じ、一覧のタイトルは変更されない
+    await expect(page.getByRole('dialog')).toBeHidden();
+    await expect(
+      page.getByRole('heading', { level: 3, name: '変更しないタスク' }),
+    ).toBeVisible();
+  });
+
+  test('タスクを削除すると一覧から消える', async ({
+    createAuthenticatedPage,
+  }) => {
+    // Given: 既存タスクが1件表示されている
+    const page = await createAuthenticatedPage();
+    await openDashboardWithTasks(page, {
+      initialTasks: [buildMockTask({ title: '消えるタスク' })],
+    });
+
+    // When: 削除ボタンをクリックする
+    await page.getByRole('button', { name: 'タスクを削除' }).click();
+
+    // Then: 一覧からタスクが消える
+    await expect(
+      page.getByRole('heading', { level: 3, name: '消えるタスク' }),
+    ).toBeHidden();
+    await expect(page.getByText('タスクがありません')).toBeVisible();
+  });
+
+  test('ステータスを変更するとバッジと選択値が更新される', async ({
+    createAuthenticatedPage,
+  }) => {
+    // Given: 未着手ステータスのタスクが1件表示されている
+    const page = await createAuthenticatedPage();
+    await openDashboardWithTasks(page, {
+      initialTasks: [
+        buildMockTask({ title: '進行させるタスク', status: 'not_started' }),
+      ],
+    });
+
+    // When: ステータスを進行中に変更する
+    await page.getByLabel('ステータスを変更').selectOption('in_progress');
+
+    // Then: 選択値とバッジ表示が進行中に更新される
+    await expect(page.getByLabel('ステータスを変更')).toHaveValue(
+      'in_progress',
+    );
+    // select/optionの候補文言と区別するため、バッジ要素(span)のみに絞り込む
+    await expect(
+      page.locator('span').filter({ hasText: /^進行中$/ }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 概要

タスクの編集・削除・ステータス変更の主要導線を検証するE2E（Playwright）テストの追加。

## ウォークスルー

- `app/client/e2e/todo/task-edit-delete-status.spec.ts` を新規作成し、以下6ケースを追加
  - 編集を保存すると一覧のタイトルが更新されモーダルが閉じる
  - タイトルを空にして保存するとバリデーションエラーが表示される
  - 編集APIが失敗するとエラーメッセージが表示されモーダルが開いたまま
  - キャンセルすると変更が破棄されモーダルが閉じる
  - タスクを削除すると一覧から消える
  - ステータスを変更するとバッジと選択値が更新される
- `app/client/e2e/todo/helpers/task-setup.ts` の `setupTaskApiMocks` を拡張し、既存のGET（一覧取得）・POST（作成）に加えてPUT（更新）・DELETE（削除）・PATCH（ステータス変更）のモックを追加
  - 更新失敗をシミュレートする `failUpdate` オプションを追加
  - 存在しないタスクIDに対するPUT/DELETE/PATCHは404を返す
- 削除・ステータス変更のAPI失敗系は、対象コンポーネント側にエラーハンドリング（UIフィードバック）が実装されていないため、本PRのスコープ外とした

## シークエンス図

```mermaid
sequenceDiagram
    participant TS as TestSpec
    participant PG as Page
    participant MK as RouteMock
    participant UI as DashboardUI

    TS->>PG: タスクを編集ボタンをクリック
    PG->>UI: 編集モーダルを表示
    TS->>UI: タイトルを入力
    TS->>PG: 保存ボタンをクリック
    UI->>MK: PUT tasks id
    MK-->>UI: 200 更新済みタスク
    UI-->>PG: 一覧を再取得して表示更新
    PG-->>TS: 更新後タイトルが表示される
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated end-to-end test configuration to use the correct API base URL.
  * Improved task operation coverage for editing, deleting, and changing status.
  * Added handling for missing tasks and simulated update failures.

* **Tests**
  * Added end-to-end coverage for task title updates, validation errors, failed saves, cancellation, deletion, and status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->